### PR TITLE
Updated Cardinal Commerce credentials.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,10 +18,10 @@ rootProject.allprojects {
         google()
         jcenter()
         maven {
-            url "https://cardinalcommerce.bintray.com/android"
+            url "https://cardinalcommerceprod.jfrog.io/artifactory/android"
             credentials {
-                username 'braintree-team-sdk@cardinalcommerce'
-                password '220cc9476025679c4e5c843666c27d97cfb0f951'
+                username 'braintree_team_sdk'
+                password 'AKCp8jQcoDy2hxSWhDAUQKXLDPDx6NYRkqrgFLRc3qDrayg6rrCbJpsKKyMwaykVL8FWusJpp'
             }
         }
     }


### PR DESCRIPTION
Updated CC credentials per [this](https://stackoverflow.com/questions/60113189/braintree-drop-in-ui-error-failed-to-resolve-org-jfrog-cardinalcommerce-gradl/68273589#68273589).